### PR TITLE
fix: increase `max_tokens`

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -26,7 +26,7 @@ const handler = async (req: NextRequest): Promise<Response> => {
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
-    max_tokens: 300,
+    max_tokens: 500,
     stream: true,
     n: 1,
   };


### PR DESCRIPTION
## Motivation

Fix #4 

For Chinese characters, setting `max_tokens` to 300 can easily exceed this threshold.

<img width="759" alt="image" src="https://user-images.githubusercontent.com/38807139/215316842-8b1b047b-357f-4253-acde-cde43d6324b5.png">
